### PR TITLE
Add Docker build setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,17 @@ Investment Portfolio Management
 ## Building
 This project uses [sbt](https://www.scala-sbt.org/) to build the microservices. Run `sbt compile` or `sbt test` from the repository root.
 
+### Building with Docker
+The repository includes a Dockerfile that builds the service, runs the tests,
+and packages the resulting JAR. Use the following commands to create and run the
+container:
+
+```bash
+# Build the image (runs the tests during the build stage)
+docker build -f docker/portfolio-management-service/Dockerfile -t portfolio-management .
+
+# Start the container with the packaged application
+docker run --rm portfolio-management
+```
+
 Additional documentation can be found in the [docs/](docs/) directory.

--- a/docker/portfolio-management-service/Dockerfile
+++ b/docker/portfolio-management-service/Dockerfile
@@ -1,0 +1,13 @@
+# Stage 0: build and test the application
+FROM hseeberger/scala-sbt:11.0.18_1.9.6_2.13.12 as builder
+WORKDIR /build
+COPY . .
+RUN sbt "project portfolioManagement" test && \
+    sbt "project portfolioManagement" package
+
+# Stage 1: run the packaged artifact
+FROM openjdk:11-jre-slim as runtime
+WORKDIR /app
+COPY --from=builder /build/src/portfolio-management-service/target/scala-2.13/*.jar app.jar
+CMD ["java", "-jar", "app.jar"]
+


### PR DESCRIPTION
## Summary
- add Dockerfile for portfolio-management-service
- document building and running via Docker

## Testing
- `sbt test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a5452afec83258069b9683b17ae6c