### PR TITLE
Fix plugin version warning and compile with Java 17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,15 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring.boot.version}</version>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
## Summary
- set `spring-boot-maven-plugin` version
- configure `maven-compiler-plugin` for Java 17

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_687b7d7ee9b483258ff98ef21d99db9d