### PR TITLE
Fix Dockerfile casing and package runnable jar

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ container:
 docker build -f docker/portfolio-management-service/Dockerfile -t portfolio-management .
 
 # Start the container with the packaged application
-docker run --rm portfolio-management
+docker run --rm -p 8080:8080 portfolio-management
 ```
 
 Additional documentation can be found in the [docs/](docs/) directory.

--- a/docker/portfolio-management-service/Dockerfile
+++ b/docker/portfolio-management-service/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 0: build and test the application
-FROM maven:3.9.6-eclipse-temurin-17 as builder
+FROM maven:3.9.6-eclipse-temurin-17 AS builder
 WORKDIR /build
 COPY pom.xml .
 RUN mvn -q dependency:resolve

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,13 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <version>${spring.boot.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>


### PR DESCRIPTION
## Summary
- update Dockerfile stage keyword to uppercase `AS`
- configure the Spring Boot Maven plugin to run the `repackage` goal
- document port mapping when running the container

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM due to network issues)*

------
https://chatgpt.com/codex/tasks/task_e_687b90c5edcc8325bd55fd0bcfa41c9e