### PR TITLE
Implement basic portfolio CRUD model

### DIFF
--- a/src/main/java/com/example/portfolio/api/PortfolioController.java
+++ b/src/main/java/com/example/portfolio/api/PortfolioController.java
@@ -1,13 +1,68 @@
 package com.example.portfolio.api;
 
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RestController;
+import com.example.portfolio.api.dto.CreatePortfolioRequest;
+import com.example.portfolio.api.dto.UpdatePortfolioRequest;
+import com.example.portfolio.domain.Portfolio;
+import com.example.portfolio.repository.PortfolioRepository;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
 @RestController
+@RequestMapping("/portfolios")
 public class PortfolioController {
-    @GetMapping("/portfolio")
-    public Mono<String> getPortfolio() {
-        return Mono.just("OK");
+
+    private final PortfolioRepository repository;
+
+    public PortfolioController(PortfolioRepository repository) {
+        this.repository = repository;
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public Mono<Map<String, String>> create(@RequestBody Mono<CreatePortfolioRequest> request) {
+        return request.flatMap(req -> {
+            String id = UUID.randomUUID().toString();
+            Portfolio portfolio = new Portfolio(id, req.userId(), List.of(), req.name(), Instant.now());
+            return repository.save(portfolio)
+                    .map(p -> Map.of("portfolioId", p.portfolioId()));
+        });
+    }
+
+    @GetMapping("/{id}")
+    public Mono<Portfolio> getById(@PathVariable String id) {
+        return repository.findById(id);
+    }
+
+    @GetMapping("/user/{userId}")
+    public Flux<Portfolio> getByUser(@PathVariable String userId) {
+        return repository.findByUserId(userId);
+    }
+
+    @PutMapping("/{id}")
+    public Mono<Portfolio> update(@PathVariable String id, @RequestBody Mono<UpdatePortfolioRequest> request) {
+        return repository.findById(id)
+                .flatMap(existing -> request.flatMap(req -> {
+                    Portfolio updated = new Portfolio(
+                            id,
+                            existing.userId(),
+                            existing.assets(),
+                            req.name(),
+                            existing.createdAt()
+                    );
+                    return repository.save(updated);
+                }));
+    }
+
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public Mono<Void> delete(@PathVariable String id) {
+        return repository.deleteById(id);
     }
 }

--- a/src/main/java/com/example/portfolio/api/dto/CreatePortfolioRequest.java
+++ b/src/main/java/com/example/portfolio/api/dto/CreatePortfolioRequest.java
@@ -1,0 +1,3 @@
+package com.example.portfolio.api.dto;
+
+public record CreatePortfolioRequest(String userId, String name) {}

--- a/src/main/java/com/example/portfolio/api/dto/UpdatePortfolioRequest.java
+++ b/src/main/java/com/example/portfolio/api/dto/UpdatePortfolioRequest.java
@@ -1,0 +1,3 @@
+package com.example.portfolio.api.dto;
+
+public record UpdatePortfolioRequest(String name) {}

--- a/src/main/java/com/example/portfolio/domain/Asset.java
+++ b/src/main/java/com/example/portfolio/domain/Asset.java
@@ -1,0 +1,3 @@
+package com.example.portfolio.domain;
+
+public record Asset(String assetId, double quantity, Currency currency) {}

--- a/src/main/java/com/example/portfolio/domain/Currency.java
+++ b/src/main/java/com/example/portfolio/domain/Currency.java
@@ -1,0 +1,3 @@
+package com.example.portfolio.domain;
+
+public record Currency(String code) {}

--- a/src/main/java/com/example/portfolio/domain/Portfolio.java
+++ b/src/main/java/com/example/portfolio/domain/Portfolio.java
@@ -1,3 +1,10 @@
 package com.example.portfolio.domain;
 
-public record Portfolio(String id, String name) {}
+import java.time.Instant;
+import java.util.List;
+
+public record Portfolio(String portfolioId,
+                        String userId,
+                        List<Asset> assets,
+                        String name,
+                        Instant createdAt) {}

--- a/src/main/java/com/example/portfolio/repository/InMemoryPortfolioRepository.java
+++ b/src/main/java/com/example/portfolio/repository/InMemoryPortfolioRepository.java
@@ -1,0 +1,38 @@
+package com.example.portfolio.repository;
+
+import com.example.portfolio.domain.Portfolio;
+import org.springframework.stereotype.Repository;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Repository
+public class InMemoryPortfolioRepository implements PortfolioRepository {
+
+    private final Map<String, Portfolio> store = new ConcurrentHashMap<>();
+
+    @Override
+    public Mono<Portfolio> findById(String id) {
+        return Mono.justOrEmpty(store.get(id));
+    }
+
+    @Override
+    public Flux<Portfolio> findByUserId(String userId) {
+        return Flux.fromIterable(store.values())
+                .filter(p -> p.userId().equals(userId));
+    }
+
+    @Override
+    public Mono<Portfolio> save(Portfolio portfolio) {
+        store.put(portfolio.portfolioId(), portfolio);
+        return Mono.just(portfolio);
+    }
+
+    @Override
+    public Mono<Void> deleteById(String id) {
+        store.remove(id);
+        return Mono.empty();
+    }
+}

--- a/src/main/java/com/example/portfolio/repository/PortfolioRepository.java
+++ b/src/main/java/com/example/portfolio/repository/PortfolioRepository.java
@@ -1,0 +1,12 @@
+package com.example.portfolio.repository;
+
+import com.example.portfolio.domain.Portfolio;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+public interface PortfolioRepository {
+    Mono<Portfolio> findById(String id);
+    Flux<Portfolio> findByUserId(String userId);
+    Mono<Portfolio> save(Portfolio portfolio);
+    Mono<Void> deleteById(String id);
+}

--- a/src/test/java/com/example/portfolio/domain/PortfolioTest.java
+++ b/src/test/java/com/example/portfolio/domain/PortfolioTest.java
@@ -2,12 +2,16 @@ package com.example.portfolio.domain;
 
 import org.junit.jupiter.api.Test;
 
+import java.time.Instant;
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 class PortfolioTest {
     @Test
     void portfolioCanBeInstantiated() {
-        Portfolio portfolio = new Portfolio("1", "Test");
-        assertThat(portfolio.id()).isEqualTo("1");
+        Portfolio portfolio = new Portfolio("1", "u1", List.of(), "Test", Instant.now());
+        assertThat(portfolio.portfolioId()).isEqualTo("1");
+        assertThat(portfolio.assets()).isEmpty();
     }
 }

--- a/src/test/java/com/example/portfolio/repository/InMemoryPortfolioRepositoryTest.java
+++ b/src/test/java/com/example/portfolio/repository/InMemoryPortfolioRepositoryTest.java
@@ -1,0 +1,22 @@
+package com.example.portfolio.repository;
+
+import com.example.portfolio.domain.Portfolio;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class InMemoryPortfolioRepositoryTest {
+
+    @Test
+    void saveAndRetrievePortfolio() {
+        PortfolioRepository repo = new InMemoryPortfolioRepository();
+        Portfolio portfolio = new Portfolio("1", "u1", List.of(), "Test", Instant.now());
+        repo.save(portfolio).block();
+
+        Portfolio found = repo.findById("1").block();
+        assertThat(found).isEqualTo(portfolio);
+    }
+}


### PR DESCRIPTION
## Summary
- implement Portfolio domain object with user and assets
- define Asset and Currency value objects
- create PortfolioRepository interface with in-memory implementation
- expand REST controller for create, retrieve, update and delete
- add simple DTOs and unit tests

## Testing
- `mvn -q test` *(fails: Could not download Spring artifacts)*

------
https://chatgpt.com/codex/tasks/task_e_687f5dd33e588325be274d8b53dee6e1