### PR TITLE
Add trade event handling

### DIFF
--- a/src/main/java/com/example/portfolio/domain/PortfolioValue.java
+++ b/src/main/java/com/example/portfolio/domain/PortfolioValue.java
@@ -1,0 +1,3 @@
+package com.example.portfolio.domain;
+
+public record PortfolioValue(double amount, Currency currency) {}

--- a/src/main/java/com/example/portfolio/event/EventPublisher.java
+++ b/src/main/java/com/example/portfolio/event/EventPublisher.java
@@ -1,0 +1,7 @@
+package com.example.portfolio.event;
+
+import reactor.core.publisher.Mono;
+
+public interface EventPublisher {
+    Mono<Void> publish(Object event);
+}

--- a/src/main/java/com/example/portfolio/event/InMemoryEventPublisher.java
+++ b/src/main/java/com/example/portfolio/event/InMemoryEventPublisher.java
@@ -1,0 +1,21 @@
+package com.example.portfolio.event;
+
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+public class InMemoryEventPublisher implements EventPublisher {
+
+    private final List<Object> events = new CopyOnWriteArrayList<>();
+
+    @Override
+    public Mono<Void> publish(Object event) {
+        events.add(event);
+        return Mono.empty();
+    }
+
+    public List<Object> events() {
+        return events;
+    }
+}

--- a/src/main/java/com/example/portfolio/event/PortfolioUpdated.java
+++ b/src/main/java/com/example/portfolio/event/PortfolioUpdated.java
@@ -1,0 +1,10 @@
+package com.example.portfolio.event;
+
+import com.example.portfolio.domain.PortfolioValue;
+import java.time.Instant;
+
+public record PortfolioUpdated(
+        String portfolioId,
+        PortfolioValue newValue,
+        Instant timestamp
+) {}

--- a/src/main/java/com/example/portfolio/event/TradeExecuted.java
+++ b/src/main/java/com/example/portfolio/event/TradeExecuted.java
@@ -1,0 +1,15 @@
+package com.example.portfolio.event;
+
+import com.example.portfolio.domain.Currency;
+import java.time.Instant;
+
+public record TradeExecuted(
+        String transactionId,
+        String portfolioId,
+        String assetId,
+        double quantity,
+        String transactionType,
+        double price,
+        Currency currency,
+        Instant timestamp
+) {}

--- a/src/main/java/com/example/portfolio/event/TradeExecutedHandler.java
+++ b/src/main/java/com/example/portfolio/event/TradeExecutedHandler.java
@@ -1,0 +1,72 @@
+package com.example.portfolio.event;
+
+import com.example.portfolio.domain.Asset;
+import com.example.portfolio.domain.Currency;
+import com.example.portfolio.domain.Portfolio;
+import com.example.portfolio.domain.PortfolioValue;
+import com.example.portfolio.repository.PortfolioRepository;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Component
+public class TradeExecutedHandler {
+
+    private final PortfolioRepository repository;
+    private final EventPublisher publisher;
+
+    public TradeExecutedHandler(PortfolioRepository repository, EventPublisher publisher) {
+        this.repository = repository;
+        this.publisher = publisher;
+    }
+
+    public Mono<Void> handle(TradeExecuted event) {
+        return repository.findById(event.portfolioId())
+                .flatMap(portfolio -> {
+                    List<Asset> updatedAssets = updateAssets(portfolio.assets(), event);
+                    Portfolio updated = new Portfolio(
+                            portfolio.portfolioId(),
+                            portfolio.userId(),
+                            updatedAssets,
+                            portfolio.name(),
+                            portfolio.createdAt()
+                    );
+                    return repository.save(updated)
+                            .flatMap(saved -> publishUpdated(saved, event.currency()));
+                })
+                .then();
+    }
+
+    private List<Asset> updateAssets(List<Asset> assets, TradeExecuted event) {
+        List<Asset> result = new ArrayList<>(assets);
+        Optional<Asset> existing = result.stream()
+                .filter(a -> a.assetId().equals(event.assetId()))
+                .findFirst();
+        double qtyChange = event.quantity() * ("BUY".equalsIgnoreCase(event.transactionType()) ? 1 : -1);
+        if (existing.isPresent()) {
+            result.remove(existing.get());
+            double newQty = existing.get().quantity() + qtyChange;
+            if (newQty > 0) {
+                result.add(new Asset(event.assetId(), newQty, existing.get().currency()));
+            }
+        } else if (qtyChange > 0) {
+            result.add(new Asset(event.assetId(), qtyChange, event.currency()));
+        }
+        return result;
+    }
+
+    private Mono<Void> publishUpdated(Portfolio portfolio, Currency currency) {
+        double totalQty = portfolio.assets().stream().mapToDouble(Asset::quantity).sum();
+        PortfolioValue value = new PortfolioValue(totalQty, currency);
+        PortfolioUpdated updatedEvent = new PortfolioUpdated(
+                portfolio.portfolioId(),
+                value,
+                Instant.now()
+        );
+        return publisher.publish(updatedEvent);
+    }
+}

--- a/src/test/java/com/example/portfolio/event/TradeExecutedHandlerTest.java
+++ b/src/test/java/com/example/portfolio/event/TradeExecutedHandlerTest.java
@@ -1,0 +1,51 @@
+package com.example.portfolio.event;
+
+import com.example.portfolio.domain.Asset;
+import com.example.portfolio.domain.Currency;
+import com.example.portfolio.domain.Portfolio;
+import com.example.portfolio.repository.InMemoryPortfolioRepository;
+import com.example.portfolio.repository.PortfolioRepository;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TradeExecutedHandlerTest {
+
+    @Test
+    void handleUpdatesPortfolioAndPublishesEvent() {
+        PortfolioRepository repo = new InMemoryPortfolioRepository();
+        InMemoryEventPublisher publisher = new InMemoryEventPublisher();
+        TradeExecutedHandler handler = new TradeExecutedHandler(repo, publisher);
+
+        Portfolio portfolio = new Portfolio("p1", "u1", List.of(), "Test", Instant.now());
+        repo.save(portfolio).block();
+
+        TradeExecuted trade = new TradeExecuted(
+                "t1",
+                "p1",
+                "AAPL",
+                10.0,
+                "BUY",
+                150.0,
+                new Currency("USD"),
+                Instant.now()
+        );
+
+        handler.handle(trade).block();
+
+        Portfolio updated = repo.findById("p1").block();
+        assertThat(updated.assets()).hasSize(1);
+        Asset asset = updated.assets().get(0);
+        assertThat(asset.assetId()).isEqualTo("AAPL");
+        assertThat(asset.quantity()).isEqualTo(10.0);
+
+        assertThat(publisher.events()).hasSize(1);
+        Object evt = publisher.events().get(0);
+        assertThat(evt).isInstanceOf(PortfolioUpdated.class);
+        PortfolioUpdated pu = (PortfolioUpdated) evt;
+        assertThat(pu.portfolioId()).isEqualTo("p1");
+    }
+}


### PR DESCRIPTION
## Summary
- implement `PortfolioValue` domain record
- add `TradeExecuted` and `PortfolioUpdated` domain events
- introduce simple `EventPublisher` with an in-memory implementation
- create `TradeExecutedHandler` to update portfolios when a trade is executed
- test event handling logic

## Testing
- `mvn -q test` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687f85e839088325b4966d8b53d02743