### PR TITLE
Fix tests and compiler plugin config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,8 +65,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.11.0</version>
                 <configuration>
-                    <source>${java.version}</source>
-                    <target>${java.version}</target>
+                    <!-- use the release flag for strict compatibility checks -->
+                    <release>${java.version}</release>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/test/java/com/example/portfolio/api/PortfolioControllerIntegrationTest.java
+++ b/src/test/java/com/example/portfolio/api/PortfolioControllerIntegrationTest.java
@@ -74,7 +74,9 @@ class PortfolioControllerIntegrationTest {
                 .expectBody()
                 .jsonPath("$.name").isEqualTo("Updated");
 
-        assertThat(repository.findById("2").block().name()).isEqualTo("Updated");
+        Portfolio updated = repository.findById("2").block();
+        assertThat(updated).isNotNull();
+        assertThat(updated.name()).isEqualTo("Updated");
     }
 
     @Test

--- a/src/test/java/com/example/portfolio/event/TradeExecutedHandlerTest.java
+++ b/src/test/java/com/example/portfolio/event/TradeExecutedHandlerTest.java
@@ -37,6 +37,7 @@ class TradeExecutedHandlerTest {
         handler.handle(trade).block();
 
         Portfolio updated = repo.findById("p1").block();
+        assertThat(updated).isNotNull();
         assertThat(updated.assets()).hasSize(1);
         Asset asset = updated.assets().get(0);
         assertThat(asset.assetId()).isEqualTo("AAPL");


### PR DESCRIPTION
## Summary
- use `release` option for `maven-compiler-plugin`
- guard repository lookups in tests to avoid potential `null`

## Testing
- `mvn -q -DskipTests=false test` *(fails: unable to resolve Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687fd97fd1588325a1f0ad9ffe5a6146